### PR TITLE
Added cache/extension-types to typeRoots for easy sharing extension types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,11 +26,29 @@
       "node_modules/@types",
       // Include papi-dts type declarations (for papi.d.ts)
       "../paranext-core/lib",
-      // Include other extensions' type declarations
+      // Include core extensions' type declarations
       "../paranext-core/extensions/src",
       // Include this extension's type declarations. It's in this location so there aren't any
       // unexpected files there for typeRoots to include
-      "src/types"
+      "src/types",
+
+      /**
+       * Add extension repos' `src/types` folders here if you want to use local development type
+       * declarations. These will override the cached extension type declarations included in
+       * final entry in this array. Note that running extensions' local development type
+       * declaration files get copied into the cached extension type declarations while running
+       * Platform.Bible in development, but adding extension repos' `src/types` folders here means
+       * the local development type declarations will always be up-to-date instead of only when
+       * Platform.Bible is running in development.
+       *
+       * @example Adding `"../paranext-extension-word-list/src/types",` includes the local version
+       * of the Word List extension's type declarations. Then, your extension can use types from the
+       * local build of the Word List extension.
+       */
+
+      // Include cached extension type declarations in case this extension needs to depend on them
+      // These are last, so any modules in the above typeRoots take precedence.
+      "../paranext-core/dev-appdata/cache/extension-types"
     ],
     // Papi exposes decorators for use in classes
     "experimentalDecorators": true,


### PR DESCRIPTION
Goes along with https://github.com/paranext/paranext-core/pull/659 and https://github.com/paranext/paranext-extension-template/pull/52

Relates to https://github.com/paranext/paranext-core/issues/365

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-extension-text-collection/26)
<!-- Reviewable:end -->
